### PR TITLE
Add appearance follows primary screen

### DIFF
--- a/app/config/windowsettings.cpp
+++ b/app/config/windowsettings.cpp
@@ -30,8 +30,8 @@ WindowSettings::WindowSettings(QWidget* parent) : QWidget(parent)
 {
     setupUi(this);
 
-    for (int i = 2; i <= QGuiApplication::screens().count(); i++)
-        kcfg_Screen->insertItem(i, xi18nc("@item:inlistbox", "Screen %1", i));
+    for (int i = 3; i <= QGuiApplication::screens().count()+1; i++)
+        kcfg_Screen->insertItem(i, xi18nc("@item:inlistbox", "Screen %1", i-1));
 
     if (QGuiApplication::screens().count() > 1)
     {

--- a/app/config/windowsettings.ui
+++ b/app/config/windowsettings.ui
@@ -319,6 +319,11 @@
           </item>
           <item>
            <property name="text">
+            <string comment="@item:inlistbox">Primary screen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string comment="@item:inlistbox">Screen 1</string>
            </property>
           </item>

--- a/app/config/yakuake.kcfg
+++ b/app/config/yakuake.kcfg
@@ -7,7 +7,7 @@
   <group name="Window">
     <entry name="Screen" type="Int">
       <label context="@label">Screen to use</label>
-      <whatsthis context="@info:whatsthis">The screen on which the application window will appear. 0 is understood to be the screen the mouse pointer is on.</whatsthis>
+      <whatsthis context="@info:whatsthis">The screen on which the application window will appear. 0 is understood to be the screen the mouse pointer is on. 1 is understood to be the primary screen.</whatsthis>
       <default>0</default>
     </entry>
     <entry name="Width" type="Int">

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -129,7 +129,9 @@ MainWindow::MainWindow(QWidget* parent)
     connect(&m_mousePoller, SIGNAL(timeout()), this, SLOT(pollMouse()));
 
     connect(KWindowSystem::self(), SIGNAL(workAreaChanged()), this, SLOT(applyWindowGeometry()));
-    connect(QApplication::desktop(), SIGNAL(screenCountChanged(int)), this, SLOT(updateScreenMenu()));
+    connect(QApplication::desktop(), SIGNAL(screenAdded(int)), this, SLOT(updateScreenMenu()));
+    connect(QApplication::desktop(), SIGNAL(screenRemoved(int)), this, SLOT(updateScreenMenu()));
+    connect(QApplication::desktop(), SIGNAL(primaryScreenChanged(int)), this, SLOT(updateScreenMenu()));
 
     applySettings();
 
@@ -665,13 +667,18 @@ void MainWindow::updateScreenMenu()
     action->setCheckable(true);
     action->setData(0);
     action->setChecked(Settings::screen() == 0);
+    
+    action = m_screenMenu->addAction(xi18nc("@item:inmenu", "Primary screen"));
+    action->setCheckable(true);
+    action->setData(1);
+    action->setChecked(Settings::screen() == 1);
 
     for (int i = 1; i <= QGuiApplication::screens().count(); i++)
     {
         action = m_screenMenu->addAction(xi18nc("@item:inmenu", "Screen %1", i));
         action->setCheckable(true);
         action->setData(i);
-        action->setChecked(i == Settings::screen());
+        action->setChecked(i+2 == Settings::screen());
     }
 
     action = m_screenMenu->menuAction();
@@ -1428,8 +1435,10 @@ int MainWindow::getScreen()
 {
     if (!Settings::screen())
         return QApplication::desktop()->screenNumber(QCursor::pos());
+    if (Settings::screen() == 1)
+        return QApplication::desktop()->primaryScreen();
     else
-        return Settings::screen() - 1;
+        return Settings::screen() - 2;
 }
 
 QRect MainWindow::getDesktopGeometry()


### PR DESCRIPTION
By setting Settings::screen to -1 the yakuake window will appear on the primary screen. This is handy, when a laptop is used in different screen configurations and setting the screen appearance to a fixed number is not feasible.